### PR TITLE
Use jogl and gluegen jars directly from processing-3.3.7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ def create_manifest
   File.open('MANIFEST.MF', 'w') do |f|
     f.puts(title)
     f.puts(version)
-    f.puts('Class-Path: gluegen-rt-2.3.2.jar jog-all-2.3.2.jar')
+    f.puts('Class-Path: gluegen-rt.jar jog-all.jar')
   end
 end
 
@@ -20,8 +20,7 @@ end
 
 desc 'Install'
 task :install do
-  sh 'mvn dependency:copy'
-  sh 'mv target/picrate-0.1.0.jar lib'
+  sh 'mv target/picrate-0.2.0.jar lib'
 end
 
 desc 'Gem'

--- a/lib/picrate/version.rb
+++ b/lib/picrate/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module PiCrate
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/picrate.gemspec
+++ b/picrate.gemspec
@@ -15,15 +15,15 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{ruby wrapper for processing-3.3.7 on raspberrypi and linux64}
   gem.homepage      = 'https://ruby-processing.github.io/PiCrate/'
   gem.files         = `git ls-files`.split($/)
-  gem.files << 'lib/picrate-0.1.0.jar'
-  gem.files << 'lib/gluegen-rt-2.3.2.jar'
-  gem.files << 'lib/jogl-all-2.3.2.jar'
-  gem.files << 'lib/gluegen-rt-2.3.2-natives-linux-amd64.jar'
-  gem.files << 'lib/gluegen-rt-2.3.2-natives-linux-armv6hf.jar'
-  # gem.files << 'lib/gluegen-rt-2.3.2-natives-linux-aarch64.jar'
-  gem.files << 'lib/jogl-all-2.3.2-natives-linux-amd64.jar'
-  gem.files << 'lib/jogl-all-2.3.2-natives-linux-armv6hf.jar'
-  # gem.files << 'lib/jogl-all-2.3.2-natives-linux-aarch64.jar'
+  gem.files << 'lib/picrate-0.2.0.jar'
+  gem.files << 'lib/gluegen-rt.jar'
+  gem.files << 'lib/jogl-all.jar'
+  gem.files << 'lib/gluegen-rt-natives-linux-amd64.jar'
+  gem.files << 'lib/gluegen-rt-natives-linux-armv6hf.jar'
+  # gem.files << 'lib/gluegen-rt-natives-linux-aarch64.jar'
+  gem.files << 'lib/jogl-all-natives-linux-amd64.jar'
+  gem.files << 'lib/jogl-all-natives-linux-armv6hf.jar'
+  # gem.files << 'lib/jogl-all-natives-linux-aarch64.jar'
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.add_development_dependency 'rake', '~> 12.3'

--- a/pom.rb
+++ b/pom.rb
@@ -1,7 +1,7 @@
 project 'picrate', 'http://maven.apache.org' do
 
   model_version '4.0.0'
-  id 'ruby-processing:picrate:0.1.0'
+  id 'ruby-processing:picrate:0.2.0'
   packaging 'jar'
 
   description 'An integrated processing-core (somewhat hacked), with additional java code for a jruby version of processing.'
@@ -35,68 +35,6 @@ project 'picrate', 'http://maven.apache.org' do
     jar 'org.processing:video:3.0.2'
     jar 'org.jogamp.jogl:jogl-all:${jogl.version}'
     jar 'org.jogamp.gluegen:gluegen-rt-main:${jogl.version}'
-
-    overrides do
-      plugin :resources, '2.6'
-      plugin :dependency, '2.10' do
-        execute_goals( id: 'default-cli',
-          artifactItems: [ { groupId:  'org.jogamp.jogl',
-            artifactId:  'jogl-all',
-            version:  '${jogl.version}',
-            type:  'jar',
-            outputDirectory: '${picrate.basedir}/lib'
-          },
-          { groupId:  'org.jogamp.gluegen',
-            artifactId:  'gluegen-rt',
-            version:  '${jogl.version}',
-            type:  'jar',
-            outputDirectory: '${picrate.basedir}/lib'
-          },
-          { groupId:  'org.jogamp.jogl',
-            artifactId:  'jogl-all',
-            version:  '${jogl.version}',
-            classifier: 'natives-linux-amd64',
-            type:  'jar',
-            outputDirectory: '${picrate.basedir}/lib'
-          },
-          { groupId:  'org.jogamp.gluegen',
-            artifactId:  'gluegen-rt',
-            version:  '${jogl.version}',
-            type:  'jar',
-            classifier: 'natives-linux-amd64',
-            outputDirectory: '${picrate.basedir}/lib'
-          },
-          # { groupId:  'org.jogamp.jogl',
-          #   artifactId:  'jogl-all',
-          #   version:  '${jogl.version}',
-          #   classifier: 'natives-linux-aarch64',
-          #   type:  'jar',
-          #   outputDirectory: '${picrate.basedir}/lib'
-          # },
-          # { groupId:  'org.jogamp.gluegen',
-          #   artifactId:  'gluegen-rt',
-          #   version:  '${jogl.version}',
-          #   type:  'jar',
-          #   classifier: 'natives-linux-aarch64',
-          #   outputDirectory: '${picrate.basedir}/lib'
-          # }
-          { groupId:  'org.jogamp.jogl',
-            artifactId:  'jogl-all',
-            version:  '${jogl.version}',
-            classifier: 'natives-linux-armv6hf',
-            type:  'jar',
-            outputDirectory: '${picrate.basedir}/lib'
-          },
-          { groupId:  'org.jogamp.gluegen',
-            artifactId:  'gluegen-rt',
-            version:  '${jogl.version}',
-            type:  'jar',
-            classifier: 'natives-linux-armv6hf',
-            outputDirectory: '${picrate.basedir}/lib'
-          }
-        ]
-      )
-    end
   end
 
   plugin( :resources, '2.7',
@@ -119,4 +57,3 @@ project 'picrate', 'http://maven.apache.org' do
             includes ['**/*.png', '*.txt']
           end
         end
-      end

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@ DO NOT MODIFIY - GENERATED CODE
   <modelVersion>4.0.0</modelVersion>
   <groupId>ruby-processing</groupId>
   <artifactId>picrate</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <name>picrate</name>
   <description>An integrated processing-core (somewhat hacked), with additional java code for a jruby version of processing.</description>
   <url>http://maven.apache.org</url>
@@ -117,73 +117,6 @@ DO NOT MODIFIY - GENERATED CODE
         </includes>
       </resource>
     </resources>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>2.6</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.10</version>
-          <executions>
-            <execution>
-              <id>default-cli</id>
-              <configuration>
-                <artifactItems>
-                  <artifactItem>
-                    <groupId>org.jogamp.jogl</groupId>
-                    <artifactId>jogl-all</artifactId>
-                    <version>${jogl.version}</version>
-                    <type>jar</type>
-                    <outputDirectory>${picrate.basedir}/lib</outputDirectory>
-                  </artifactItem>
-                  <artifactItem>
-                    <groupId>org.jogamp.gluegen</groupId>
-                    <artifactId>gluegen-rt</artifactId>
-                    <version>${jogl.version}</version>
-                    <type>jar</type>
-                    <outputDirectory>${picrate.basedir}/lib</outputDirectory>
-                  </artifactItem>
-                  <artifactItem>
-                    <groupId>org.jogamp.jogl</groupId>
-                    <artifactId>jogl-all</artifactId>
-                    <version>${jogl.version}</version>
-                    <classifier>natives-linux-amd64</classifier>
-                    <type>jar</type>
-                    <outputDirectory>${picrate.basedir}/lib</outputDirectory>
-                  </artifactItem>
-                  <artifactItem>
-                    <groupId>org.jogamp.gluegen</groupId>
-                    <artifactId>gluegen-rt</artifactId>
-                    <version>${jogl.version}</version>
-                    <type>jar</type>
-                    <classifier>natives-linux-amd64</classifier>
-                    <outputDirectory>${picrate.basedir}/lib</outputDirectory>
-                  </artifactItem>
-                  <artifactItem>
-                    <groupId>org.jogamp.jogl</groupId>
-                    <artifactId>jogl-all</artifactId>
-                    <version>${jogl.version}</version>
-                    <classifier>natives-linux-armv6hf</classifier>
-                    <type>jar</type>
-                    <outputDirectory>${picrate.basedir}/lib</outputDirectory>
-                  </artifactItem>
-                  <artifactItem>
-                    <groupId>org.jogamp.gluegen</groupId>
-                    <artifactId>gluegen-rt</artifactId>
-                    <version>${jogl.version}</version>
-                    <type>jar</type>
-                    <classifier>natives-linux-armv6hf</classifier>
-                    <outputDirectory>${picrate.basedir}/lib</outputDirectory>
-                  </artifactItem>
-                </artifactItems>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
@ShadowfeindX this might be interesting for propane, it seems that just by using jars directly from processing-3.3.7 distro (rather than dependency copy from maven) fixes opengl on raspberrypi. NB using picrate.jar (in place of core.jar and rpextras.jar) works fine.